### PR TITLE
Fix phred function in 2vcf script

### DIFF
--- a/scripts/2vcf.py
+++ b/scripts/2vcf.py
@@ -14,8 +14,7 @@ from sklearn.metrics import roc_curve
 
 def phred(vals):
     """ apply the phred scale to the vals provided """
-    return -10*np.log10(1-vals)
-    return -10*np.ma.log10(1-vals).filled(-3) # fill all infinite values with a phred scale of 30
+    return -10 * np.ma.log10(1 - vals).filled(-3)
 
 def plot_line(lst, show_discards=False):
     plt.clf()


### PR DESCRIPTION
## Summary
- remove obsolete return in phred()
- ensure phred() returns masked log10 results

## Testing
- `python scripts/2vcf.py --help` *(fails: ModuleNotFoundError: No module named 'pysam')*