### PR TITLE
Remove unused matplotlib import

### DIFF
--- a/scripts/metrics_table.py
+++ b/scripts/metrics_table.py
@@ -2,7 +2,6 @@
 
 import sys
 import argparse
-import matplotlib
 import numpy as np
 import pandas as pd
 from pathlib import Path


### PR DESCRIPTION
## Summary
- remove unused matplotlib import from `metrics_table.py`

## Testing
- `python scripts/metrics_table.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*