### PR TITLE
Fix shebangs and reorder RF parameters

### DIFF
--- a/scripts/train_RF.R
+++ b/scripts/train_RF.R
@@ -1,11 +1,11 @@
-#!/usr/bin/env RScript
+#!/usr/bin/env Rscript
 
 # This R script trains a random forest classifier. We recommend using the Snakefile-classify pipeline to run this script.
 
 # param1: The path to a TSV containing the data on which to train the classifier.
 #         The last column must contain binarized, true labels. Note that NA's should be removed and numerical columns should be normalized (via norm_numerics.awk)
-# param2: The path to an RDA file in which to store the trained classifier. This file is required input to predict_RF.R
-# param3: An integer (0 or 1) indicating whether to attempt to balance the data
+# param2: An integer (0 or 1) indicating whether to attempt to balance the data
+# param3: The path to an RDA file in which to store the trained classifier. This file is required input to predict_RF.R
 # param4: The path to a TSV in which to store information about how important the random forest deems each column in the data you provided.
 # param5 (optional): The path to a TSV in which to store the results of cross validation on the classifier's hyperparameters. If not specified, cross validation will not be performed
 

--- a/scripts/tune_plot.R
+++ b/scripts/tune_plot.R
@@ -1,4 +1,4 @@
-#!/usr/bin/env RScript
+#!/usr/bin/env Rscript
 
 # This R script can be used to visualize the output of the hyperparameter tuning step in train_RF.R
 


### PR DESCRIPTION
## Summary
- fix case of shebang in R scripts
- reorder parameter docs in `train_RF.R` to match the expected CLI

## Testing
- `git status --short`